### PR TITLE
Compute HandlerError retryability given error type

### DIFF
--- a/src/nexusrpc/__init__.py
+++ b/src/nexusrpc/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from . import handler
 from ._common import (
     HandlerError,
+    HandlerErrorRetryBehavior,
     HandlerErrorType,
     InputT,
     Link,
@@ -42,6 +43,7 @@ __all__ = [
     "handler",
     "HandlerError",
     "HandlerErrorType",
+    "HandlerErrorRetryBehavior",
     "InputT",
     "LazyValue",
     "Link",

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -58,23 +58,27 @@ class HandlerError(Exception):
 
         :param type: The :py:class:`HandlerErrorType` of the error.
 
-        :param retry_behavior: The retry behavior for the error. The
-                               :py:meth:`retryable` property will return the boolean
-                               value based on this value. If None, then the default
-                               behavior for the error type is used. See
-                               https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
+        :param retry_behavior: Optional retry behavior for the error.
         """
         super().__init__(message)
         self._type = type
         self._retry_behavior = retry_behavior
 
     @property
+    def retry_behavior(self) -> Optional[HandlerErrorRetryBehavior]:
+        """
+        The retry behavior set for this error.
+        """
+        return self._retry_behavior
+
+    @property
     def retryable(self) -> bool:
         """
         Whether this error should be retried.
 
-        If None, then the default behavior for the error type is used.
-        See https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
+        If :py:attr:`retry_behavior` is None, then the default behavior for the error
+        type is used. See
+        https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
         """
         if self._retry_behavior == HandlerErrorRetryBehavior.RETRYABLE:
             return True

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -48,7 +48,7 @@ class HandlerError(Exception):
         message: str,
         *,
         type: HandlerErrorType,
-        retryable: Optional[bool] = None,
+        retry_behavior: Optional[HandlerErrorRetryBehavior] = None,
     ):
         """
         Initialize a new HandlerError.
@@ -56,23 +56,50 @@ class HandlerError(Exception):
         :param message: A descriptive message for the error. This will become the
                         `message` in the resulting Nexus Failure object.
 
-        :param type:
+        :param type: The :py:class:`HandlerErrorType` of the error.
 
-        :param retryable:
+        :param retry_behavior: The retry behavior for the error. The
+                               :py:meth:`retryable` property will return the boolean
+                               value based on this value. If None, then the default
+                               behavior for the error type is used. See
+                               https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
         """
         super().__init__(message)
         self._type = type
-        self._retryable = retryable
+        self._retry_behavior = retry_behavior
 
     @property
-    def retryable(self) -> Optional[bool]:
+    def retryable(self) -> bool:
         """
         Whether this error should be retried.
 
-        If None, then the default behavior for the error type should be used.
+        If None, then the default behavior for the error type is used.
         See https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
         """
-        return self._retryable
+        if self._retry_behavior == HandlerErrorRetryBehavior.RETRYABLE:
+            return True
+        elif self._retry_behavior == HandlerErrorRetryBehavior.NON_RETRYABLE:
+            return False
+
+        non_retryable_types = {
+            HandlerErrorType.BAD_REQUEST,
+            HandlerErrorType.UNAUTHENTICATED,
+            HandlerErrorType.UNAUTHORIZED,
+            HandlerErrorType.NOT_FOUND,
+            HandlerErrorType.NOT_IMPLEMENTED,
+        }
+        retryable_types = {
+            HandlerErrorType.RESOURCE_EXHAUSTED,
+            HandlerErrorType.INTERNAL,
+            HandlerErrorType.UNAVAILABLE,
+            HandlerErrorType.UPSTREAM_TIMEOUT,
+        }
+        if self._type in non_retryable_types:
+            return False
+        elif self._type in retryable_types:
+            return True
+        else:
+            return True
 
     @property
     def type(self) -> HandlerErrorType:
@@ -83,6 +110,22 @@ class HandlerError(Exception):
         https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors.
         """
         return self._type
+
+
+class HandlerErrorRetryBehavior(Enum):
+    """
+    Retry behavior for a handler error.
+    """
+
+    RETRYABLE = "RETRYABLE"
+    """
+    The error should be retried.
+    """
+
+    NON_RETRYABLE = "NON_RETRYABLE"
+    """
+    The error should not be retried.
+    """
 
 
 class OperationError(Exception):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,41 @@
+from nexusrpc._common import HandlerError, HandlerErrorRetryBehavior, HandlerErrorType
+
+
+def test_handler_error_retryable_type():
+    retryable_error_type = HandlerErrorType.RESOURCE_EXHAUSTED
+    assert HandlerError(
+        "test",
+        type=retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.RETRYABLE,
+    ).retryable
+
+    assert not HandlerError(
+        "test",
+        type=retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.NON_RETRYABLE,
+    ).retryable
+
+    assert HandlerError(
+        "test",
+        type=retryable_error_type,
+    ).retryable
+
+
+def test_handler_error_non_retryable_type():
+    non_retryable_error_type = HandlerErrorType.BAD_REQUEST
+    assert HandlerError(
+        "test",
+        type=non_retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.RETRYABLE,
+    ).retryable
+
+    assert not HandlerError(
+        "test",
+        type=non_retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.NON_RETRYABLE,
+    ).retryable
+
+    assert not HandlerError(
+        "test",
+        type=non_retryable_error_type,
+    ).retryable


### PR DESCRIPTION
I'm following Go and Java by introducing the "retry behavior" concept. It allows making a distinction between what the user inputs and what the computed property outputs.