### PR TITLE
Eliminate "retry behavior" enum

### DIFF
--- a/src/nexusrpc/__init__.py
+++ b/src/nexusrpc/__init__.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from . import handler
 from ._common import (
     HandlerError,
-    HandlerErrorRetryBehavior,
     HandlerErrorType,
     InputT,
     Link,
@@ -43,7 +42,6 @@ __all__ = [
     "handler",
     "HandlerError",
     "HandlerErrorType",
-    "HandlerErrorRetryBehavior",
     "InputT",
     "LazyValue",
     "Link",

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -73,7 +73,8 @@ class HandlerError(Exception):
         """
         return self._retryable_override
 
-    def should_be_retried(self) -> bool:
+    @property
+    def retryable(self) -> bool:
         """
         Whether this error should be retried.
 

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -48,29 +48,30 @@ class HandlerError(Exception):
         message: str,
         *,
         type: HandlerErrorType,
-        retryable: Optional[bool] = None,
+        retryable_override: Optional[bool] = None,
     ):
         """
         Initialize a new HandlerError.
 
-        :param message: A descriptive message for the error. This will become the
-                        `message` in the resulting Nexus Failure object.
+        :param message: A descriptive message for the error. This will become
+                        the `message` in the resulting Nexus Failure object.
 
         :param type: The :py:class:`HandlerErrorType` of the error.
 
-        :param retryable: Optionally set whether the error should be retried. By default,
-                          the error type is used to determine if the error should be retried.
+        :param retryable_override: Optionally set whether the error should be
+                                   retried. By default, the error type is used
+                                   to determine if the error should be retried.
         """
         super().__init__(message)
         self._type = type
-        self._retryable = retryable
+        self._retryable_override = retryable_override
 
     @property
-    def retryable(self) -> Optional[bool]:
+    def retryable_override(self) -> Optional[bool]:
         """
-        The optional retryability set when this error was created.
+        The optional retryability override set when this error was created.
         """
-        return self._retryable
+        return self._retryable_override
 
     def should_be_retried(self) -> bool:
         """
@@ -80,8 +81,8 @@ class HandlerError(Exception):
         type is used. See
         https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
         """
-        if self._retryable is not None:
-            return self._retryable
+        if self._retryable_override is not None:
+            return self._retryable_override
 
         non_retryable_types = {
             HandlerErrorType.BAD_REQUEST,

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -60,7 +60,7 @@ class HandlerError(Exception):
 
         :param retryable_override: Optionally set whether the error should be
                                    retried. By default, the error type is used
-                                   to determine if the error should be retried.
+                                   to determine this.
         """
         super().__init__(message)
         self._type = type
@@ -78,8 +78,8 @@ class HandlerError(Exception):
         """
         Whether this error should be retried.
 
-        If :py:attr:`retryable` is None, then the default behavior for the error
-        type is used. See
+        If :py:attr:`retryable_override` is None, then the default behavior for the
+        error type is used. See
         https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
         """
         if self._retryable_override is not None:

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -72,7 +72,6 @@ class HandlerError(Exception):
         """
         return self._retryable
 
-    @property
     def should_be_retried(self) -> bool:
         """
         Whether this error should be retried.

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -68,7 +68,7 @@ class HandlerError(Exception):
     @property
     def retryable(self) -> Optional[bool]:
         """
-        The retry behavior set for this error.
+        The optional retryability set when this error was created.
         """
         return self._retryable
 
@@ -80,8 +80,8 @@ class HandlerError(Exception):
         type is used. See
         https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors
         """
-        if self.retryable is not None:
-            return self.retryable
+        if self._retryable is not None:
+            return self._retryable
 
         non_retryable_types = {
             HandlerErrorType.BAD_REQUEST,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,18 +7,18 @@ def test_handler_error_retryable_type():
         "test",
         type=retryable_error_type,
         retryable_override=True,
-    ).should_be_retried()
+    ).retryable
 
     assert not HandlerError(
         "test",
         type=retryable_error_type,
         retryable_override=False,
-    ).should_be_retried()
+    ).retryable
 
     assert HandlerError(
         "test",
         type=retryable_error_type,
-    ).should_be_retried()
+    ).retryable
 
 
 def test_handler_error_non_retryable_type():
@@ -27,15 +27,15 @@ def test_handler_error_non_retryable_type():
         "test",
         type=non_retryable_error_type,
         retryable_override=True,
-    ).should_be_retried()
+    ).retryable
 
     assert not HandlerError(
         "test",
         type=non_retryable_error_type,
         retryable_override=False,
-    ).should_be_retried()
+    ).retryable
 
     assert not HandlerError(
         "test",
         type=non_retryable_error_type,
-    ).should_be_retried()
+    ).retryable

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,4 @@
-from nexusrpc._common import HandlerError, HandlerErrorRetryBehavior, HandlerErrorType
+from nexusrpc._common import HandlerError, HandlerErrorType
 
 
 def test_handler_error_retryable_type():
@@ -6,19 +6,19 @@ def test_handler_error_retryable_type():
     assert HandlerError(
         "test",
         type=retryable_error_type,
-        retry_behavior=HandlerErrorRetryBehavior.RETRYABLE,
-    ).retryable
+        retryable=True,
+    ).should_be_retried
 
     assert not HandlerError(
         "test",
         type=retryable_error_type,
-        retry_behavior=HandlerErrorRetryBehavior.NON_RETRYABLE,
-    ).retryable
+        retryable=False,
+    ).should_be_retried
 
     assert HandlerError(
         "test",
         type=retryable_error_type,
-    ).retryable
+    ).should_be_retried
 
 
 def test_handler_error_non_retryable_type():
@@ -26,16 +26,16 @@ def test_handler_error_non_retryable_type():
     assert HandlerError(
         "test",
         type=non_retryable_error_type,
-        retry_behavior=HandlerErrorRetryBehavior.RETRYABLE,
-    ).retryable
+        retryable=True,
+    ).should_be_retried
 
     assert not HandlerError(
         "test",
         type=non_retryable_error_type,
-        retry_behavior=HandlerErrorRetryBehavior.NON_RETRYABLE,
-    ).retryable
+        retryable=False,
+    ).should_be_retried
 
     assert not HandlerError(
         "test",
         type=non_retryable_error_type,
-    ).retryable
+    ).should_be_retried

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,18 +7,18 @@ def test_handler_error_retryable_type():
         "test",
         type=retryable_error_type,
         retryable=True,
-    ).should_be_retried
+    ).should_be_retried()
 
     assert not HandlerError(
         "test",
         type=retryable_error_type,
         retryable=False,
-    ).should_be_retried
+    ).should_be_retried()
 
     assert HandlerError(
         "test",
         type=retryable_error_type,
-    ).should_be_retried
+    ).should_be_retried()
 
 
 def test_handler_error_non_retryable_type():
@@ -27,15 +27,15 @@ def test_handler_error_non_retryable_type():
         "test",
         type=non_retryable_error_type,
         retryable=True,
-    ).should_be_retried
+    ).should_be_retried()
 
     assert not HandlerError(
         "test",
         type=non_retryable_error_type,
         retryable=False,
-    ).should_be_retried
+    ).should_be_retried()
 
     assert not HandlerError(
         "test",
         type=non_retryable_error_type,
-    ).should_be_retried
+    ).should_be_retried()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,41 @@
+from nexusrpc._common import HandlerError, HandlerErrorRetryBehavior, HandlerErrorType
+
+
+def test_handler_error_retryable_type():
+    retryable_error_type = HandlerErrorType.RESOURCE_EXHAUSTED
+    assert HandlerError(
+        "test",
+        type=retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.RETRYABLE,
+    ).retryable
+
+    assert not HandlerError(
+        "test",
+        type=retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.NON_RETRYABLE,
+    ).retryable
+
+    assert HandlerError(
+        "test",
+        type=retryable_error_type,
+    ).retryable
+
+
+def test_handler_error_non_retryable_type():
+    non_retryable_error_type = HandlerErrorType.BAD_REQUEST
+    assert HandlerError(
+        "test",
+        type=non_retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.RETRYABLE,
+    ).retryable
+
+    assert not HandlerError(
+        "test",
+        type=non_retryable_error_type,
+        retry_behavior=HandlerErrorRetryBehavior.NON_RETRYABLE,
+    ).retryable
+
+    assert not HandlerError(
+        "test",
+        type=non_retryable_error_type,
+    ).retryable

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,13 +6,13 @@ def test_handler_error_retryable_type():
     assert HandlerError(
         "test",
         type=retryable_error_type,
-        retryable=True,
+        retryable_override=True,
     ).should_be_retried()
 
     assert not HandlerError(
         "test",
         type=retryable_error_type,
-        retryable=False,
+        retryable_override=False,
     ).should_be_retried()
 
     assert HandlerError(
@@ -26,13 +26,13 @@ def test_handler_error_non_retryable_type():
     assert HandlerError(
         "test",
         type=non_retryable_error_type,
-        retryable=True,
+        retryable_override=True,
     ).should_be_retried()
 
     assert not HandlerError(
         "test",
         type=non_retryable_error_type,
-        retryable=False,
+        retryable_override=False,
     ).should_be_retried()
 
     assert not HandlerError(


### PR DESCRIPTION
`retryable_override: Optional[bool]` to capture the user's input, and a computed property `err.retryable` for the computed output.

```
err = HandlerError(type=UNAVAILABLE)
err.retryable           # => True
err.retryable_override  # => None

err = HandlerError(type=UNAVAILABLE, retryable_override=False)
err.retryable           # => False
err.retryable_override  # => False
```