### PR TITLE
[5/5] Clarify role of `get_operation_factory`

### DIFF
--- a/tests/handler/test_request_routing.py
+++ b/tests/handler/test_request_routing.py
@@ -5,7 +5,7 @@ from typing_extensions import dataclass_transform
 
 import nexusrpc
 from nexusrpc import LazyValue
-from nexusrpc._util import get_operation_factory, get_service_definition
+from nexusrpc._util import get_operation, get_service_definition
 from nexusrpc.handler import (
     Handler,
     StartOperationContext,
@@ -33,7 +33,7 @@ class _TestCase(_BaseTestCase):
         async def _op_impl(self, ctx: StartOperationContext, input: None) -> bool:
             assert (service_defn := get_service_definition(self.__class__))
             assert ctx.service == service_defn.name
-            _, op_handler_op_defn = get_operation_factory(self.op)
+            op_handler_op_defn = get_operation(self.op)
             assert op_handler_op_defn
             assert service_defn.operation_definitions.get(ctx.operation)
             return True

--- a/tests/handler/test_sync_operation_handler_decorator_creates_valid_operation_handler.py
+++ b/tests/handler/test_sync_operation_handler_decorator_creates_valid_operation_handler.py
@@ -35,7 +35,7 @@ class MyServiceHandler:
 
 def test_def_sync_handler():
     user_instance = MyServiceHandler()
-    op_handler_factory, _ = get_operation_factory(user_instance.my_def_op)
+    op_handler_factory = get_operation_factory(user_instance.my_def_op)
     assert op_handler_factory
     op_handler = op_handler_factory(user_instance)
     assert not is_async_callable(op_handler.start)
@@ -54,7 +54,7 @@ def test_def_sync_handler():
 @pytest.mark.asyncio
 async def test_async_def_sync_handler():
     user_instance = MyServiceHandler()
-    op_handler_factory, _ = get_operation_factory(user_instance.my_async_def_op)
+    op_handler_factory = get_operation_factory(user_instance.my_async_def_op)
     assert op_handler_factory
     op_handler = op_handler_factory(user_instance)
     assert is_async_callable(op_handler.start)


### PR DESCRIPTION
This is PR 5/5 in a stack.

This is a small cleanup. Currently the `get_operation_factory` method is used by the Temporal SDK (vendored, since it is not exposed). This commit will allow the Temporal SDK to use `get_operation_definition` which is exposed.