### PR TITLE
Add CONFLICT and REQUEST_TIMEOUT handler error types

### DIFF
--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -90,9 +90,11 @@ class HandlerError(Exception):
             HandlerErrorType.UNAUTHENTICATED,
             HandlerErrorType.UNAUTHORIZED,
             HandlerErrorType.NOT_FOUND,
+            HandlerErrorType.CONFLICT,
             HandlerErrorType.NOT_IMPLEMENTED,
         }
         retryable_types = {
+            HandlerErrorType.REQUEST_TIMEOUT,
             HandlerErrorType.RESOURCE_EXHAUSTED,
             HandlerErrorType.INTERNAL,
             HandlerErrorType.UNAVAILABLE,
@@ -148,6 +150,22 @@ class HandlerErrorType(Enum):
     The requested resource could not be found but may be available in the future.
 
     Subsequent requests by the client are permissible but not advised.
+    """
+
+    REQUEST_TIMEOUT = "REQUEST_TIMEOUT"
+    """
+    Returned by the server when it has given up handling a request. This may occur by enforcing a client
+    provided `Request-Timeout` or for any arbitrary reason such as enforcing some configurable limit.
+
+    Subsequent requests by the client are permissible.
+    """
+
+    CONFLICT = "CONFLICT"
+    """
+    The request could not be made due to a conflict. This may happen when trying to create an operation that
+    has already been started.
+
+    Clients should not retry this request unless advised otherwise.
     """
 
     RESOURCE_EXHAUSTED = "RESOURCE_EXHAUSTED"


### PR DESCRIPTION
## Description

- Adds `REQUEST_TIMEOUT` and `CONFLICT` to `HandlerErrorType` enum
- `REQUEST_TIMEOUT` is retryable by default  
- `CONFLICT` is non-retryable by default
- Updates retryable logic to include new error types

Fixes #22