### PR TITLE
💥 Remove FetchInfo and FetchResult handler requests

### DIFF
--- a/src/nexusrpc/__init__.py
+++ b/src/nexusrpc/__init__.py
@@ -23,8 +23,6 @@ from ._common import (
     Link,
     OperationError,
     OperationErrorState,
-    OperationInfo,
-    OperationState,
     OutputT,
 )
 from ._serializer import Content, LazyValue
@@ -49,8 +47,6 @@ __all__ = [
     "OperationDefinition",
     "OperationError",
     "OperationErrorState",
-    "OperationInfo",
-    "OperationState",
     "OutputT",
     "service",
     "ServiceDefinition",

--- a/src/nexusrpc/_common.py
+++ b/src/nexusrpc/_common.py
@@ -225,32 +225,6 @@ class OperationError(Exception):
         return self._state
 
 
-class OperationState(Enum):
-    """
-    Describes the current state of an operation.
-    """
-
-    RUNNING = "running"
-    """
-    The operation is running.
-    """
-
-    SUCCEEDED = "succeeded"
-    """
-    The operation succeeded.
-    """
-
-    FAILED = "failed"
-    """
-    The operation failed.
-    """
-
-    CANCELED = "canceled"
-    """
-    The operation was canceled.
-    """
-
-
 class OperationErrorState(Enum):
     """
     The state of an operation as described by an :py:class:`OperationError`.
@@ -264,23 +238,6 @@ class OperationErrorState(Enum):
     CANCELED = "canceled"
     """
     The operation was canceled.
-    """
-
-
-@dataclass(frozen=True)
-class OperationInfo:
-    """
-    Information about an operation.
-    """
-
-    token: str
-    """
-    Token identifying the operation (returned on operation start).
-    """
-
-    state: OperationState
-    """
-    The operation's state.
     """
 
 

--- a/src/nexusrpc/handler/__init__.py
+++ b/src/nexusrpc/handler/__init__.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 from ._common import (
     CancelOperationContext,
-    FetchOperationInfoContext,
-    FetchOperationResultContext,
     OperationContext,
     StartOperationContext,
     StartOperationResultAsync,
@@ -25,8 +23,6 @@ from ._operation_handler import OperationHandler as OperationHandler
 
 __all__ = [
     "CancelOperationContext",
-    "FetchOperationInfoContext",
-    "FetchOperationResultContext",
     "Handler",
     "OperationContext",
     "OperationHandler",

--- a/src/nexusrpc/handler/_common.py
+++ b/src/nexusrpc/handler/_common.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import timedelta
 from typing import Any, Generic, Optional
 
 from nexusrpc._common import Link, OutputT
@@ -82,27 +81,6 @@ class CancelOperationContext(OperationContext):
     """Context for the cancel method.
 
     Includes information from the request."""
-
-
-@dataclass(frozen=True)
-class FetchOperationInfoContext(OperationContext):
-    """Context for the fetch_info method.
-
-    Includes information from the request."""
-
-
-@dataclass(frozen=True)
-class FetchOperationResultContext(OperationContext):
-    """Context for the fetch_result method.
-
-    Includes information from the request."""
-
-    wait: Optional[timedelta] = None
-    """
-    Allowed time to wait for the operation result (long poll). If by the end of the
-    wait period the operation is still running, a response with 412 status code will
-    be returned, and the caller may re-issue the request to start a new long poll.
-    """
 
 
 @dataclass(frozen=True)

--- a/src/nexusrpc/handler/_operation_handler.py
+++ b/src/nexusrpc/handler/_operation_handler.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Awaitable
 from typing import Any, Callable, Generic, Optional, Union
 
-from nexusrpc._common import InputT, OperationInfo, OutputT, ServiceHandlerT
+from nexusrpc._common import InputT, OutputT, ServiceHandlerT
 from nexusrpc._service import Operation, OperationDefinition, ServiceDefinition
 from nexusrpc._util import (
     get_operation,
@@ -17,8 +17,6 @@ from nexusrpc._util import (
 
 from ._common import (
     CancelOperationContext,
-    FetchOperationInfoContext,
-    FetchOperationResultContext,
     StartOperationContext,
     StartOperationResultAsync,
     StartOperationResultSync,
@@ -52,24 +50,6 @@ class OperationHandler(ABC, Generic[InputT, OutputT]):
 
         Returns the result synchronously, or returns an operation token. Which path is
         taken may be decided at operation handling time.
-        """
-        ...
-
-    @abstractmethod
-    def fetch_info(
-        self, ctx: FetchOperationInfoContext, token: str
-    ) -> Union[OperationInfo, Awaitable[OperationInfo]]:
-        """
-        Return information about the current status of the operation.
-        """
-        ...
-
-    @abstractmethod
-    def fetch_result(
-        self, ctx: FetchOperationResultContext, token: str
-    ) -> Union[OutputT, Awaitable[OutputT]]:
-        """
-        Return the result of the operation.
         """
         ...
 
@@ -117,20 +97,6 @@ class SyncOperationHandler(OperationHandler[InputT, OutputT]):
         version, see :py:class:`nexusrpc.handler.syncio.SyncOperationHandler`.
         """
         return StartOperationResultSync(await self._start(ctx, input))
-
-    async def fetch_info(
-        self, ctx: FetchOperationInfoContext, token: str
-    ) -> OperationInfo:
-        raise NotImplementedError(
-            "Cannot fetch operation info for an operation that responded synchronously."
-        )
-
-    async def fetch_result(
-        self, ctx: FetchOperationResultContext, token: str
-    ) -> OutputT:
-        raise NotImplementedError(
-            "Cannot fetch the result of an operation that responded synchronously."
-        )
 
     async def cancel(self, ctx: CancelOperationContext, token: str) -> None:
         raise NotImplementedError(

--- a/src/nexusrpc/handler/_syncio.py
+++ b/src/nexusrpc/handler/_syncio.py
@@ -4,14 +4,12 @@ from typing import (
     Callable,
 )
 
-from nexusrpc._common import InputT, OperationInfo, OutputT
+from nexusrpc._common import InputT, OutputT
 from nexusrpc._util import (
     is_async_callable,
 )
 from nexusrpc.handler._common import (
     CancelOperationContext,
-    FetchOperationInfoContext,
-    FetchOperationResultContext,
     StartOperationContext,
     StartOperationResultSync,
 )
@@ -51,16 +49,6 @@ class SyncOperationHandler(OperationHandler[InputT, OutputT]):
         Start the operation and return its final result synchronously.
         """
         return StartOperationResultSync(self._start(ctx, input))
-
-    def fetch_info(self, ctx: FetchOperationInfoContext, token: str) -> OperationInfo:
-        raise NotImplementedError(
-            "Cannot fetch operation info for an operation that responded synchronously."
-        )
-
-    def fetch_result(self, ctx: FetchOperationResultContext, token: str) -> OutputT:
-        raise NotImplementedError(
-            "Cannot fetch the result of an operation that responded synchronously."
-        )
 
     def cancel(self, ctx: CancelOperationContext, token: str) -> None:
         raise NotImplementedError(

--- a/tests/handler/test_async_operation.py
+++ b/tests/handler/test_async_operation.py
@@ -1,20 +1,10 @@
-import dataclasses
 import uuid
-from datetime import timedelta
 
 import pytest
 
-from nexusrpc import (
-    HandlerError,
-    HandlerErrorType,
-    LazyValue,
-    OperationInfo,
-    OperationState,
-)
+from nexusrpc import LazyValue
 from nexusrpc.handler import (
     CancelOperationContext,
-    FetchOperationInfoContext,
-    FetchOperationResultContext,
     Handler,
     OperationHandler,
     StartOperationContext,
@@ -38,23 +28,6 @@ class MyAsyncOperationHandler(OperationHandler[int, int]):
     async def cancel(self, ctx: CancelOperationContext, token: str) -> None:
         del _operation_results[token]
 
-    async def fetch_info(
-        self, ctx: FetchOperationInfoContext, token: str
-    ) -> OperationInfo:
-        assert token in _operation_results
-        return OperationInfo(
-            token=token,
-            state=OperationState.RUNNING,
-        )
-
-    async def fetch_result(self, ctx: FetchOperationResultContext, token: str) -> int:
-        if ctx.wait:
-            raise HandlerError(
-                "Operation timed out",
-                type=HandlerErrorType.UPSTREAM_TIMEOUT,
-            )
-        return _operation_results[token]
-
 
 @service_handler
 class MyService:
@@ -77,27 +50,6 @@ async def test_async_operation_happy_path():
     )
     assert isinstance(start_result, StartOperationResultAsync)
     assert start_result.token
-
-    fetch_info_ctx = FetchOperationInfoContext(
-        service="MyService",
-        operation="incr",
-        headers={},
-    )
-    info = await handler.fetch_operation_info(fetch_info_ctx, start_result.token)
-    assert info.state == OperationState.RUNNING
-
-    fetch_result_ctx = FetchOperationResultContext(
-        service="MyService",
-        operation="incr",
-        headers={},
-    )
-    result = await handler.fetch_operation_result(fetch_result_ctx, start_result.token)
-    assert result == 2
-
-    # Fetch it again but with wait set
-    fetch_result_ctx = dataclasses.replace(fetch_result_ctx, wait=timedelta(seconds=0))
-    with pytest.raises(NotImplementedError):
-        await handler.fetch_operation_result(fetch_result_ctx, start_result.token)
 
     cancel_ctx = CancelOperationContext(
         service="MyService",

--- a/tests/handler/test_handler_validates_service_handler_collection.py
+++ b/tests/handler/test_handler_validates_service_handler_collection.py
@@ -5,11 +5,8 @@ correctly.
 
 import pytest
 
-from nexusrpc import OperationInfo
 from nexusrpc.handler import (
     CancelOperationContext,
-    FetchOperationInfoContext,
-    FetchOperationResultContext,
     Handler,
     OperationHandler,
     StartOperationContext,
@@ -40,18 +37,6 @@ def test_services_are_collected():
             ctx: CancelOperationContext,
             token: str,
         ) -> None: ...
-
-        async def fetch_info(
-            self,
-            ctx: FetchOperationInfoContext,
-            token: str,
-        ) -> OperationInfo: ...
-
-        async def fetch_result(
-            self,
-            ctx: FetchOperationResultContext,
-            token: str,
-        ) -> int: ...
 
     @service_handler
     class Service1:

--- a/tests/handler/test_service_handler_decorator_results_in_correctly_functioning_operation_factories.py
+++ b/tests/handler/test_service_handler_decorator_results_in_correctly_functioning_operation_factories.py
@@ -12,8 +12,6 @@ from nexusrpc import InputT, OutputT
 from nexusrpc._util import get_service_definition, is_async_callable
 from nexusrpc.handler import (
     CancelOperationContext,
-    FetchOperationInfoContext,
-    FetchOperationResultContext,
     OperationHandler,
     StartOperationContext,
     StartOperationResultAsync,
@@ -47,16 +45,6 @@ class ManualOperationDefinition(_TestCase):
                     self, ctx: StartOperationContext, input: int
                 ) -> StartOperationResultSync[int]:
                     return StartOperationResultSync(7)
-
-                def fetch_info(
-                    self, ctx: FetchOperationInfoContext, token: str
-                ) -> nexusrpc.OperationInfo:
-                    raise NotImplementedError
-
-                def fetch_result(
-                    self, ctx: FetchOperationResultContext, token: str
-                ) -> int:
-                    raise NotImplementedError
 
                 def cancel(self, ctx: CancelOperationContext, token: str) -> None:
                     raise NotImplementedError


### PR DESCRIPTION
## Description

Remove the following:
- FetchInfo and FetchResult requests from AbstractHandler and Handler classes
- fetch_info and fetch_result methods from OperationHandler abstract class  
- fetch_info and fetch_result methods from both SyncOperationHandler classes
- FetchOperationInfoContext and FetchOperationResultContext classes
- OperationInfo class and its associated OperationState enum

Fix #23